### PR TITLE
Added role_name to the Ansible Galaxy metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   author: John Freeman
+  role_name: antigen
   description: Role for installing the Antigen plugin manger for Zsh and using it to configure Zsh.
   company: GantSign Ltd.
   license: MIT


### PR DESCRIPTION
Needed since Ansible Galaxy 3 to have a role name different to the repo name.