### PR TITLE
Renamed repository to follow new Ansible convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Ansible Role: Antigen
 =======================
 
-[![Build Status](https://travis-ci.com/gantsign/ansible-role-antigen.svg?branch=master)](https://travis-ci.com/gantsign/ansible-role-antigen)
+[![Build Status](https://travis-ci.com/gantsign/ansible_role_antigen.svg?branch=master)](https://travis-ci.com/gantsign/ansible_role_antigen)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.antigen-blue.svg)](https://galaxy.ansible.com/gantsign/antigen)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-antigen/master/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible_role_antigen/master/LICENSE)
 
 Role to install the [Antigen](http://antigen.sharats.me/) plugin manger for Zsh
 and use it to configure Zsh.

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,19 +9,19 @@ lint:
   name: yamllint
 
 platforms:
-  - name: ansible-role-antigen-debian-min
+  - name: ansible_role_antigen_debian_min
     image: debian:8
-  - name: ansible-role-antigen-debian-max
+  - name: ansible_role_antigen_debian_max
     image: debian:9
-  - name: ansible-role-antigen-ubuntu-min
+  - name: ansible_role_antigen_ubuntu_min
     image: ubuntu:14.04
-  - name: ansible-role-antigen-ubuntu-max
+  - name: ansible_role_antigen_ubuntu_max
     image: ubuntu:18.04
-  - name: ansible-role-antigen-centos
+  - name: ansible_role_antigen_centos
     image: centos:7
-  - name: ansible-role-antigen-fedora
+  - name: ansible_role_antigen_fedora
     image: fedora:28
-  - name: ansible-role-antigen-opensuse-leap
+  - name: ansible_role_antigen_opensuse
     image: opensuse:42.2
 
 provisioner:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -25,7 +25,7 @@
         mode: 'u=rwx,go=r'
 
   roles:
-    - role: ansible-role-antigen
+    - role: ansible_role_antigen
       users:
         - username: test_usr1
           antigen_libraries:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-# vars file for ansible-role-antigen
+# vars file for ansible_role_antigen


### PR DESCRIPTION
Role names must now use underscores rather than dashes.