### PR TITLE
Pinned Antigen version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ Role Variables
 The following variables will change the behavior of this role:
 
 ```yaml
+# Antigen version number
+antigen_version: '2.0.2'
+
+# SHA256 sum for the redistributable package
+antigen_redis_sha256sum: 'f47ec933b32c578abe8cb39b24e0ddd114ef5cc01b3c05bcb634859ead31493f'
+
+# Should Oh-My-Zsh be installed with Antigen (doesn't call `antigen use`)
+antigen_install_oh_my_zsh: yes
+
+# Mirror location for Antigen download
+antigen_redis_mirror: 'https://github.com/zsh-users/antigen/releases/download/v{{ antigen_version }}'
+
+# Directory to store files downloaded for Antigen installation on the remote box
+antigen_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
+
 # Antigen is installed per user so you need to specify the users to install it for
 users:
   - username: # The username of the user to install Antigen for

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,15 @@
 ---
+# Antigen version number
+antigen_version: '2.0.2'
+
+# SHA256 sum for the redistributable package
+antigen_redis_sha256sum: 'f47ec933b32c578abe8cb39b24e0ddd114ef5cc01b3c05bcb634859ead31493f'
+
 # Should Oh-My-Zsh be installed with Antigen (doesn't call `antigen use`)
 antigen_install_oh_my_zsh: yes
+
+# Mirror location for Antigen download
+antigen_redis_mirror: 'https://github.com/zsh-users/antigen/releases/download/v{{ antigen_version }}'
+
+# Directory to store files downloaded for Antigen installation on the remote box
+antigen_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -24,6 +24,17 @@ def test_antigen_install(File, username):
     'test_usr1',
     'test_usr2',
 ])
+def test_antigen_install_file(File, username):
+    antigen = File('/home/' + username + '/.antigen/antigen.zsh')
+    assert antigen.exists
+    assert antigen.is_file
+    assert antigen.user == username
+
+
+@pytest.mark.parametrize('username', [
+    'test_usr1',
+    'test_usr2',
+])
 def test_oh_my_zsh_install(File, username):
     antigen = File('/home/' + username +
                    '/.antigen/bundles/robbyrussell/oh-my-zsh')

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,18 +7,41 @@
   with_items:
     - git
     - zsh
+    - tar
 
-- name: clone antigen for users
-  tags:
-    # Suppress warning: [ANSIBLE0006] git used in place of git module
-    # Git module doesn't allow us to set `core.autocrlf=input`.
-    - skip_ansible_lint
+- name: create download directory
+  file:
+    path: '{{ antigen_download_dir }}'
+    state: directory
+    mode: 'u=rwx,go=rx'
+
+- name: download Antigen
+  get_url:
+    url: '{{ antigen_redis_mirror }}/{{ antigen_redis_filename }}'
+    dest: '{{ antigen_download_dir }}/{{ antigen_local_filename }}'
+    sha256sum: '{{ antigen_redis_sha256sum }}'
+    mode: 'u=rw,go=r'
+
+- name: create install directory
   become: yes
   become_user: '{{ item.username }}'
-  command: 'git clone -c core.autocrlf=input --depth=1 https://github.com/zsh-users/antigen.git ~/.antigen'
-  args:
-    creates: '~{{ item.username }}/.antigen'
-  when: (item.antigen_libraries is defined) or (item.antigen_theme is defined) or (item.antigen_bundles is defined)
+  file:
+    path: '~{{ item.username }}/.antigen'
+    state: directory
+    mode: 'u=rwx,go=rx'
+  with_items: '{{ users }}'
+
+- name: install Antigen
+  become: yes
+  unarchive:
+    src: '{{ antigen_download_dir }}/{{ antigen_local_filename }}'
+    remote_src: yes
+    dest: '~{{ item.username }}/.antigen'
+    extra_opts:
+      - '--strip-components=1'
+    creates: '~{{ item.username }}/.antigen/antigen.zsh'
+    owner: '{{ item.username }}'
+    mode: 'go-w'
   with_items: '{{ users }}'
 
 - name: install oh-my-zsh

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,10 @@
 ---
-# vars file for ansible_role_antigen
+# The root folder of this Antigen installation
+antigen_home: '~/.antigen'
+
+# File name for the Antigen redistributable installation file
+antigen_redis_filename: 'v{{ antigen_version }}.tar.gz'
+
+# Local file name for the Antigen redistributable installation file (needs to
+# have the package name to avoid conflicts)
+antigen_local_filename: 'antigen-{{ antigen_version }}.tar.gz'


### PR DESCRIPTION
Pinned the Antigen version to the 2.0.2 release.

Later versions suffer from the following bug: https://github.com/zsh-users/antigen/issues/583