### PR TITLE
Fixed openSUSE support

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,6 +8,7 @@
     - git
     - zsh
     - tar
+    - gzip
 
 - name: create download directory
   file:


### PR DESCRIPTION
You now need the `gzip` dependency as well as the `tar` dependency.