### PR TITLE
Increased minimum Ansible version to 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,22 @@ env:
 jobs:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=centos
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=debian_max
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=debian_min
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=ubuntu_max
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=ubuntu_min
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=opensuse
     - env:
         - MOLECULEW_ANSIBLE=2.9.1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ particular Antigen bundles. You can find details of that role at
 Requirements
 ------------
 
-* Ansible >= 2.7
+* Ansible >= 2.8
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Role for installing the Antigen plugin manger for Zsh and using it to configure Zsh.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: 2.8
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.8.