### PR TITLE
Add antigen reset command to .antigenrc

### DIFF
--- a/templates/antigenrc.j2
+++ b/templates/antigenrc.j2
@@ -19,3 +19,6 @@ unset i
 source ~/.antigen-etc/theme.zsh
 
 antigen apply
+
+# The antigen_theme will not reload if the cache wasn't reset
+antigen reset


### PR DESCRIPTION
The antigen_theme will not reload if the cache wasn't reset

Tested on ubuntu 20.04.3 LTS