### PR TITLE
Fixed to make theme optional

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -81,7 +81,7 @@ for i in ~/.antigen-etc/bundle.d/*.zsh; do
 done
 unset i
 
-source ~/.antigen-etc/theme.zsh
+[[ -f ~/.antigen-etc/theme.zsh ]] && source ~/.antigen-etc/theme.zsh
 
 antigen apply
 '''.strip()

--- a/templates/antigenrc.j2
+++ b/templates/antigenrc.j2
@@ -16,6 +16,6 @@ for i in ~/.antigen-etc/bundle.d/*.zsh; do
 done
 unset i
 
-source ~/.antigen-etc/theme.zsh
+[[ -f ~/.antigen-etc/theme.zsh ]] && source ~/.antigen-etc/theme.zsh
 
 antigen apply


### PR DESCRIPTION
Allows for missing `antigen_theme:` attributes, in case the theme is to be defined elsewhere,
without throwing `no such file or directory: /root/.antigen-etc/theme.zsh` to stderr on each init.